### PR TITLE
Update waftool to use current features

### DIFF
--- a/wtools/autoconfig.py
+++ b/wtools/autoconfig.py
@@ -175,5 +175,6 @@ def fprocess_mergejs(self):
 
 @conf
 def pbl_autoconfprogram(self,*k,**kw):
-	kw['features']='c cprogram cprogram_pebble_app autoconf mergejs'
+	kw['bin_type']='app'
+	kw['features']='c cprogram pebble_cprogram autoconf mergejs'
 	return self(*k,**kw)


### PR DESCRIPTION
`cprogram_pebble_app` has been cleaned up into `pebble_cprogram` with a BuildContext attribute of `bin_type` equal to `app` (as of Pebble SDK 3.12 and after).
